### PR TITLE
Upgrade pointycastle dependency version to 3.1.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  pointycastle: ^3.0.1
+  pointycastle: 3.1.1
   asn1lib: ^1.0.0
 
 dev_dependencies:


### PR DESCRIPTION
This Pull Request sets the pointycastle dependency version to a specific release to prevent unfixed errors when building for web.

# Pull Request Checklist 

* [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [X] My changes are [rebased](http://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`trunk`](https://github.com/konstantinullrich/crypton/tree/trunk) branch
* [X] Ran ´dartfmt -w lib test example´
* [X] All tests are passing
* [X] My changes are ready to be shipped to users


## Issues affected
<!-- Use 'Fixes #1' for Bug fixes and 'Closes #1' for every other issue affected -->
Fixes #27 